### PR TITLE
Keep sync HTTP header dict case-insensitive

### DIFF
--- a/upbankapi/client/_sync.py
+++ b/upbankapi/client/_sync.py
@@ -58,7 +58,7 @@ class Client(ClientBase):
             data = {}
         else:
             data = response.json()
-        return self._handle_response(data, response.status_code, dict(response.headers))
+        return self._handle_response(data, response.status_code, response.headers)
 
     def ping(self) -> str:
         """Retrieves the users unique id and checks if the token is valid.


### PR DESCRIPTION
Without this, checking the rate limiting header doesn't work, because the check uses a different case to the received header. requests has a perfectly good case-insensitive dictionary, so we may as well use it.